### PR TITLE
Fix/falsy rivoli code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @etalab/fantoir [![npm version](https://img.shields.io/npm/v/@etalab/fantoir.svg)](https://www.npmjs.com/package/@etalab/fantoir)
+# @ban-team/fantoir [![npm version](https://img.shields.io/npm/v/@ban-team/fantoir.svg)](https://www.npmjs.com/package/@ban-team/fantoir)
 
 Bibliothèque permettant d'interroger facilement la base [FANTOIR](https://www.data.gouv.fr/fr/datasets/fichier-fantoir-des-voies-et-lieux-dits/).
 
@@ -9,13 +9,13 @@ Cette bibliothèque nécessite [Node.js](https://nodejs.org) version 10 ou supé
 ### Installation
 
 ```
-yarn add @etalab/fantoir
+yarn add @ban-team/fantoir
 ```
 
 ### Utilisation
 
 ```js
-const {createFantoirCommune} = require('@etalab/fantoir')
+const {createFantoirCommune} = require('@ban-team/fantoir')
 const fantoirCommune = await createFantoirCommune('54099', options)
 
 // Rechercher une voie

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ function computeStringContext(str) {
 function selectBestResult(results, baseScore, ctx) {
   const activeResults = results.filter(r => !r.dateAnnulation)
 
-  const scoredResults = (activeResults.length > 1 ? activeResults : results).map(r => {
+  const scoredResults = (activeResults.length > 0 ? activeResults : results).map(r => {
     const minLeven = min(r.libelleStringContexts.map(strContext => {
       return leven(ctx.significantWordsString, strContext.significantWordsString)
     }))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ban-team/fantoir",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Toolkit for FANTOIR data manipulation in JS",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "@etalab/fantoir",
+  "name": "@ban-team/fantoir",
   "version": "0.14.1",
   "description": "Toolkit for FANTOIR data manipulation in JS",
   "publishConfig": {
     "access": "public"
   },
   "main": "lib",
-  "repository": "git@github.com:etalab/fantoir.git",
+  "repository": "https://github.com/BaseAdresseNationale/fantoir",
+  "homepage": "https://github.com/BaseAdresseNationale/fantoir",
   "author": "Jérôme Desboeufs <jerome.desboeufs@data.gouv.fr>",
   "license": "MIT",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ban-team/fantoir",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Toolkit for FANTOIR data manipulation in JS",
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,13 +50,13 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@keyv/sqlite@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@keyv/sqlite/-/sqlite-3.5.1.tgz#425e433f4c6e14546cc7875995e6d4e726134fad"
-  integrity sha512-xoPcE/F5UPK6beRwocoJpiYbBTMeIDAktFIy7LoovdFj/0aRjoFNbiqLzrj31KYFi9zrTPz6w99wH/fluPi9Vg==
+"@keyv/sqlite@^3.6.2":
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@keyv/sqlite/-/sqlite-3.6.2.tgz#1ab562caf3867d48a07b96ef10ec2d94a9b58346"
+  integrity sha512-DSLP25bhnBnAhLnSbfk2j2xq2lP9XaaYL3voXZJUANNrWH9Ho3Zx16c9EFbtBT24iXGPD2mqSSAklSeiiaTb3w==
   dependencies:
     pify "^5.0.0"
-    sqlite3 "^5.0.3"
+    sqlite3 "^5.1.2"
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.9"
@@ -3321,10 +3321,10 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sqlite3@^5.0.3:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.0.8.tgz#b4b7eab7156debec80866ef492e01165b4688272"
-  integrity sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==
+sqlite3@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.1.2.tgz#f50d5b1482b6972fb650daf6f718e6507c6cfb0f"
+  integrity sha512-D0Reg6pRWAFXFUnZKsszCI67tthFD8fGPewRddDCX6w4cYwz3MbvuwRICbL+YQjBAh9zbw+lJ/V9oC8nG5j6eg==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
     node-addon-api "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,13 +50,13 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@keyv/sqlite@^3.6.2":
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/@keyv/sqlite/-/sqlite-3.6.2.tgz#1ab562caf3867d48a07b96ef10ec2d94a9b58346"
-  integrity sha512-DSLP25bhnBnAhLnSbfk2j2xq2lP9XaaYL3voXZJUANNrWH9Ho3Zx16c9EFbtBT24iXGPD2mqSSAklSeiiaTb3w==
+"@keyv/sqlite@^3.5.1":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@keyv/sqlite/-/sqlite-3.6.4.tgz#5582efe86e3fbbf9a65b895973d73d6d5950c879"
+  integrity sha512-nE7bjOU6lmGn3QBkaAZS+LLvBHebBKDwDbMGlTbhRNJoREam69LZewspGbePb8dpZS1C6IazedVRCq2eb5kFWw==
   dependencies:
     pify "^5.0.0"
-    sqlite3 "^5.1.2"
+    sqlite3 "^5.1.4"
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.9"
@@ -3321,10 +3321,10 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sqlite3@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.1.2.tgz#f50d5b1482b6972fb650daf6f718e6507c6cfb0f"
-  integrity sha512-D0Reg6pRWAFXFUnZKsszCI67tthFD8fGPewRddDCX6w4cYwz3MbvuwRICbL+YQjBAh9zbw+lJ/V9oC8nG5j6eg==
+sqlite3@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.1.4.tgz#35f83d368963168b324ad2f0fffce09f3b8723a7"
+  integrity sha512-i0UlWAzPlzX3B5XP2cYuhWQJsTtlMD6obOa1PgeEQ4DHEXUuyJkgv50I3isqZAP5oFc2T8OFvakmDh2W6I+YpA==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
     node-addon-api "^4.2.0"


### PR DESCRIPTION
La librairie Fantoir renvoie parfois de mauvais codes Rivoli

Cela se produit lorsque l'adresse disposait précédemment d'un code Rivoli qui a ensuite été remplacé. Dans ce cas, le dernier code entré (donc, le nouveau) est systématiquement ignoré.

Cette PR corrige ce problème.
fix #22 