### PR TITLE
Upgraded minor and patch package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "lint": "xo"
   },
   "dependencies": {
-    "@etalab/adresses-util": "^0.8.2",
-    "@keyv/sqlite": "^3.5.1",
-    "keyv": "^4.2.8",
+    "@ban-team/adresses-util": "^0.9.0",
+    "@keyv/sqlite": "^3.6.5",
+    "keyv": "^4.5.2",
     "leven": "^3.1.0",
     "lodash": "^4.17.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@etalab/adresses-util@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@etalab/adresses-util/-/adresses-util-0.8.2.tgz#697c3ca9ed2e6103650a8f3c43fa2ae9caec360f"
-  integrity sha512-PsZfyECOvW6y5WzPq3NqaBk53CMcq9bNdcG8IzoFkAIf03RbFCMtSYFrhfOkJXa7qAxHJbESYBuiEPbaxCzZYw==
+"@ban-team/adresses-util@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/adresses-util/-/adresses-util-0.9.0.tgz#7b137c3507a1c543d0f91d60ceff478363a9d5ba"
+  integrity sha512-d64e1HRxuAcn5z7JDPHbavVg6nJrBoFBL0qSMUwIPX5Y1uAqT5AdFcCQ/TRGguR35BinVBMocQ0QAA3pFOCNGg==
   dependencies:
     "@turf/distance" "^6.3.0"
     leven "^3.1.0"
@@ -50,13 +50,13 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@keyv/sqlite@^3.5.1":
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/@keyv/sqlite/-/sqlite-3.6.4.tgz#5582efe86e3fbbf9a65b895973d73d6d5950c879"
-  integrity sha512-nE7bjOU6lmGn3QBkaAZS+LLvBHebBKDwDbMGlTbhRNJoREam69LZewspGbePb8dpZS1C6IazedVRCq2eb5kFWw==
+"@keyv/sqlite@^3.6.5":
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/@keyv/sqlite/-/sqlite-3.6.5.tgz#d16aaf45397942486dca3cb10ef4840fa164e0bc"
+  integrity sha512-PZPsXcZYHPKUCX1DO7e6dTMGmk5aX7uW8QFzEavOPRMVloIp2QMv+Glt162pu+Dw5NunJinCbvD2DvYwinyNZw==
   dependencies:
     pify "^5.0.0"
-    sqlite3 "^5.1.4"
+    sqlite3 "^5.1.6"
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.9"
@@ -140,11 +140,6 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
-
-"@types/json-buffer@~3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/json-buffer/-/json-buffer-3.0.0.tgz#85c1ff0f0948fc159810d4b5be35bf8c20875f64"
-  integrity sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -599,14 +594,6 @@ component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
-
-compress-brotli@^1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/compress-brotli/-/compress-brotli-1.3.8.tgz#0c0a60c97a989145314ec381e84e26682e7b38db"
-  integrity sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==
-  dependencies:
-    "@types/json-buffer" "~3.0.0"
-    json-buffer "~3.0.1"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1984,7 +1971,7 @@ js-yaml@^3.13.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-json-buffer@3.0.1, json-buffer@~3.0.1:
+json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
@@ -2012,12 +1999,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-keyv@^4.2.8:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.2.8.tgz#6c91189fe6134d8a526cb360566693c095fcfb60"
-  integrity sha512-IZZo6krhHWPhgsP5mBkEdPopVPN/stgCnBVuqi6dda/Nm5mDTOSVTrFMkWqlJsDum+B0YSe887tNxdjDWkO7aQ==
+keyv@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.2.tgz#0e310ce73bf7851ec702f2eaf46ec4e3805cce56"
+  integrity sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==
   dependencies:
-    compress-brotli "^1.3.8"
     json-buffer "3.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
@@ -3321,10 +3307,10 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sqlite3@^5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.1.4.tgz#35f83d368963168b324ad2f0fffce09f3b8723a7"
-  integrity sha512-i0UlWAzPlzX3B5XP2cYuhWQJsTtlMD6obOa1PgeEQ4DHEXUuyJkgv50I3isqZAP5oFc2T8OFvakmDh2W6I+YpA==
+sqlite3@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.1.6.tgz#1d4fbc90fe4fbd51e952e0a90fd8f6c2b9098e97"
+  integrity sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
     node-addon-api "^4.2.0"


### PR DESCRIPTION
Context : 

Some of the package versions on "fantoir" are outdated. Here is the overview of the outdated packages :

<img width="278" alt="Capture d’écran 2023-04-05 à 15 49 44" src="https://user-images.githubusercontent.com/52679050/230100807-d475fc0b-17fa-43c6-9a19-1c46626ddd51.png">

Actions :

This pull request aims to upgraded the packages :

- Patch and minor versions for all the outdated packages : no breaking changes.

The other package version upgrades (major upgrades) would need to migrate the to the ESModule model. 

Result :

<img width="249" alt="Capture d’écran 2023-04-05 à 15 50 02" src="https://user-images.githubusercontent.com/52679050/230101100-c3e38417-826e-4ee1-9017-a8b2b2e9415a.png">
