### PR TITLE
corrections / amélioration calcul du meilleur candidat fantoir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ function computeStringContext(str) {
   return {normalizedString, phoneticString, significantWords, significantWordsString}
 }
 
-function selectBestResult(results, baseScore, ctx) {
+function selectBestResult(nomVoieMaj, results, baseScore, ctx) {
   const activeResults = results.filter(r => !r.dateAnnulation)
 
   const scoredResults = (activeResults.length > 0 ? activeResults : results).map(r => {
@@ -57,7 +57,9 @@ function selectBestResult(results, baseScore, ctx) {
 
     const malusTypeVoie = r.typeVoie !== 'voie'
 
-    return {...r, score: baseScore + (10 * minLeven) + malusTypeVoie}
+    const levenMaj = leven(nomVoieMaj, r.libelle.toString())
+
+    return {...r, score: baseScore + (10 * (minLeven + levenMaj)) + malusTypeVoie}
   })
 
   return minBy(scoredResults, 'score')
@@ -92,7 +94,7 @@ async function createFantoirCommune(codeCommune, options = {}) {
 
   function findVoie(nomVoie, communeScope, forceScope = false) {
     const ctx = computeStringContext(nomVoie)
-
+    const nomVoieMaj = nomVoie.toUpperCase()
     if (ctx.significantWords.length < 2) {
       stats.tooShort++
       return
@@ -109,7 +111,7 @@ async function createFantoirCommune(codeCommune, options = {}) {
 
     if (significantWordsCompareResults.length > 0) {
       stats.significantWords++
-      return selectBestResult(significantWordsCompareResults, 1000, ctx)
+      return selectBestResult(nomVoieMaj, significantWordsCompareResults, 1000, ctx)
     }
 
     // PHONETIC
@@ -121,7 +123,7 @@ async function createFantoirCommune(codeCommune, options = {}) {
 
     if (phoneticCompareResults.length > 0) {
       stats.phonetic++
-      return selectBestResult(phoneticCompareResults, 2000, ctx)
+      return selectBestResult(nomVoieMaj, phoneticCompareResults, 2000, ctx)
     }
 
     // OVERLAPPING
@@ -133,7 +135,7 @@ async function createFantoirCommune(codeCommune, options = {}) {
 
     if (overlapCompareResults.length > 0) {
       stats.overlap++
-      return selectBestResult(overlapCompareResults, 3000, ctx)
+      return selectBestResult(nomVoieMaj, overlapCompareResults, 3000, ctx)
     }
 
     if (communeScope && !forceScope) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,13 +48,18 @@ function computeStringContext(str) {
 }
 
 function selectBestResult(nomVoieMaj, results, baseScore, ctx) {
-  const activeResults = results.filter(r => !r.dateAnnulation)
+  const activeResults = results
 
   const scoredResults = (activeResults.length > 0 ? activeResults : results).map(r => {
-    const minLeven = min(r.libelleStringContexts.map(strContext => {
-      return leven(ctx.significantWordsString, strContext.significantWordsString)
-    }))
+    const minLeven = min(r.libelleStringContexts.map(stringContext => {
+      const pos1 = ctx.significantWordsString.indexOf('(')
+      const cleaned1 = pos1 > 0 ? ctx.significantWordsString.slice(0, pos1) : ctx.significantWordsString
+      const pos2 = stringContext.significantWordsString.indexOf('(')
+      const cleaned2 = pos2 > 0 ? stringContext.significantWordsString.slice(0, pos2) : stringContext.significantWordsString
 
+      return leven(cleaned1, cleaned2)
+    }
+    ))
     const malusTypeVoie = r.typeVoie !== 'voie'
 
     const levenMaj = leven(nomVoieMaj, r.libelle.toString())
@@ -100,8 +105,13 @@ async function createFantoirCommune(codeCommune, options = {}) {
   }
 
   function findVoie(nomVoie, communeScope, forceScope = false) {
-    const ctx = computeStringContext(nomVoie)
-    const nomVoieMaj = nomVoie.toUpperCase()
+    // On nettoie tout ce qu'il y a après une parenthèse ouvrante.
+    const pos = nomVoie.indexOf('(')
+    const nomVoieCleaned = pos > 0 ? nomVoie.slice(0, pos) : nomVoie
+
+    const ctx = computeStringContext(nomVoieCleaned)
+    const nomVoieMaj = nomVoieCleaned.toUpperCase()
+
     if (ctx.significantWords.length < 2) {
       stats.tooShort++
       return

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const Keyv = require('keyv')
 const leven = require('leven')
-const {uniq, chain, min, keyBy, minBy} = require('lodash')
+const {uniq, chain, min, keyBy, minBy, maxBy} = require('lodash')
 const {extractSignificantWords, normalizeBase, phonetizeWords, overlap} = require('@etalab/adresses-util/lib/voies')
 const {getCommuneActuelle} = require('./cog')
 
@@ -61,8 +61,15 @@ function selectBestResult(nomVoieMaj, results, baseScore, ctx) {
 
     return {...r, score: baseScore + (10 * (minLeven + levenMaj)) + malusTypeVoie}
   })
+  // Si le meilleur score est une voie annulée avec successeur ou si le meilleur score est une voie non annulée, on la renvoie
 
-  return minBy(scoredResults, 'score')
+  const bestResult = minBy(scoredResults, 'score')
+  if ((bestResult.annulee && bestResult.successeur) || (!bestResult.annulee)) {
+    return bestResult
+  }
+
+  // Sinon on renvoie le max (si un seul result alors max = min)
+  return maxBy(scoredResults, 'score')
 }
 
 async function createFantoirCommune(codeCommune, options = {}) {


### PR DESCRIPTION
Corrections / améliorations : 

- permet de discriminer les candidats lorsque les mots directeurs sont les mêmes en comparant l'ensemble du libellé de la voie
- Permet de diminuer le nombre de codes fantoir annulés renvoyés dans les résultats en cherchant un autre candidat  en cas de code annulé sans successeur. 
- Permet de nettoyer les noms de communes anciennes dans les libellés BAN / DGFIP pour les mauvaises pratiques en cas de commune fusionnée, entre parenthèses nom ancienne commune.


permet de résoudre en partie le ticket ban plateforme 151

A associer à une PR ban-plateforme.